### PR TITLE
Features/repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>runtime</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,16 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
@@ -98,6 +108,9 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+
+
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,33 @@
             <artifactId>spring-batch-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.wiremock/wiremock-standalone -->
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>3.9.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-junit-jupiter-no-dependencies</artifactId>
+            <version>5.14.0</version>
+        </dependency>
+
+
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>

--- a/src/main/java/org/devlouco/bacensenderhub/models/CompanyModel.java
+++ b/src/main/java/org/devlouco/bacensenderhub/models/CompanyModel.java
@@ -1,0 +1,42 @@
+package org.devlouco.bacensenderhub.models;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Entity
+public class CompanyModel {
+
+    public CompanyModel(int coop, String cnpj) {
+        this.coop = coop;
+        this.cnpj = cnpj;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long ID;
+
+
+    @Min(1)
+    @Max(4)
+    @Column(unique = true, nullable = false, length = 4)
+    private int coop;
+
+    @NotBlank
+    @Size(max = 14)
+    @Column(unique = true, nullable = false)
+    private String cnpj;
+
+    @OneToOne(mappedBy = "company", cascade = CascadeType.ALL)
+    private CredentialsModel credentials;
+
+
+
+}

--- a/src/main/java/org/devlouco/bacensenderhub/models/CompanyModel.java
+++ b/src/main/java/org/devlouco/bacensenderhub/models/CompanyModel.java
@@ -37,6 +37,44 @@ public class CompanyModel {
     @OneToOne(mappedBy = "company", cascade = CascadeType.ALL)
     private CredentialsModel credentials;
 
+    public static Builder builder(){
+        return new Builder();
+    }
+
+    public final static class Builder{
+
+        private Long ID;
+        private int coop;
+        private String cnpj;
+        private CredentialsModel credentials;
+
+        public Builder withID(Long ID){
+            this.ID = ID;
+            return this;
+        }
+
+
+        public Builder withCoop(int coop){
+            this.coop = coop;
+            return this;
+        }
+
+        public Builder withCnpj(String cnpj){
+            this.cnpj = cnpj;
+            return this;
+        }
+
+        public Builder withCredentials(CredentialsModel credentials){
+            this.credentials = credentials;
+            return this;
+        }
+
+        public CompanyModel build(){
+            return new CompanyModel(this.ID,this.coop,this.cnpj,this.credentials);
+        }
+
+    }
+
 
 
 }

--- a/src/main/java/org/devlouco/bacensenderhub/models/CredentialsModel.java
+++ b/src/main/java/org/devlouco/bacensenderhub/models/CredentialsModel.java
@@ -33,4 +33,38 @@ public class CredentialsModel {
     @JoinColumn(name = "company_id", referencedColumnName = "ID")
     private CompanyModel company;
 
+    public static Builder builder(){
+        return new Builder();
+    }
+
+    public final static class Builder{
+
+        private Long ID;
+        private String login;
+        private String password;
+        private CompanyModel company;
+
+        public Builder withID(Long ID){
+            this.ID = ID;
+            return this;
+        }
+        public Builder withLogin(String login){
+            this.login = login;
+            return this;
+        }
+        public Builder withPassword(String password){
+            this.password = password;
+            return this;
+        }
+        public Builder withCompany(CompanyModel company){
+            this.company = company;
+            return this;
+        }
+
+        public CredentialsModel build(){
+            return new CredentialsModel(ID, login, password, company);
+        }
+
+    }
+
 }

--- a/src/main/java/org/devlouco/bacensenderhub/models/CredentialsModel.java
+++ b/src/main/java/org/devlouco/bacensenderhub/models/CredentialsModel.java
@@ -1,0 +1,36 @@
+package org.devlouco.bacensenderhub.models;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Entity
+public class CredentialsModel {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long ID;
+
+    @NotBlank
+    @NotNull
+    @Column(unique = true, nullable = false)
+    private String login;
+
+    @NotBlank
+    @NotNull
+    @Column(unique = true, nullable = false)
+    private String password;
+
+    @NotNull
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "company_id", referencedColumnName = "ID")
+    private CompanyModel company;
+
+}

--- a/src/main/java/org/devlouco/bacensenderhub/models/LinkResponseModel.java
+++ b/src/main/java/org/devlouco/bacensenderhub/models/LinkResponseModel.java
@@ -1,0 +1,31 @@
+package org.devlouco.bacensenderhub.models;
+
+import lombok.*;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+@XmlType(propOrder = {"href", "rel","type"})
+public class LinkResponseModel {
+
+    @XmlAttribute(name ="href")
+    private String href;
+
+    @XmlAttribute(name = "rel")
+    private String rel;
+
+    @XmlAttribute(name = "type")
+    private String type;
+
+
+
+}

--- a/src/main/java/org/devlouco/bacensenderhub/models/ProtocolModel.java
+++ b/src/main/java/org/devlouco/bacensenderhub/models/ProtocolModel.java
@@ -1,0 +1,187 @@
+package org.devlouco.bacensenderhub.models;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+
+import javax.xml.bind.annotation.*;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Objects;
+
+@Entity
+@XmlRootElement(name = "Parametros")
+@XmlType(propOrder = {"idetification","hash","size","docName","observation","recipient"})
+public class ProtocolModel {
+
+    public ProtocolModel(Long ID, LocalDate date, String idetification, String hash, long size, String docName, String observation, String recipient, CompanyModel company, byte[] filesBytes) {
+        this.ID = ID;
+        this.date = date;
+        this.idetification = idetification;
+        this.hash = hash;
+        this.size = size;
+        this.docName = docName;
+        this.observation = observation;
+        this.recipient = recipient;
+        this.company = company;
+        this.filesBytes = filesBytes;
+    }
+
+    public ProtocolModel() {}
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ID;
+
+    @NotNull
+    private LocalDate date;
+
+
+    @NotBlank
+    private String idetification;
+
+    @NotBlank
+    @Size(max = 64)
+    private String hash;
+
+
+    private long size;
+
+    @NotBlank
+    private String docName;
+
+    private String observation;
+
+    @NotBlank
+
+    private String recipient;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "company_id")
+    private CompanyModel company;
+
+    private byte filesBytes[];
+
+
+    @XmlTransient
+    public Long getID() {
+        return ID;
+    }
+
+    public void setID(Long ID) {
+        this.ID = ID;
+    }
+
+    @XmlTransient
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    @XmlElement(name = "IdentificadorDocumento")
+    public String getIdetification() {
+        return idetification;
+    }
+
+    public void setIdetification(String idetification) {
+        this.idetification = idetification;
+    }
+
+    @XmlElement(name = "Hash")
+    public String getHash() {
+        return hash;
+    }
+
+    public void setHash(String hash) {
+        this.hash = hash;
+    }
+
+    @XmlElement(name = "Tamanho")
+    public long getSize() {
+        return size;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
+    }
+    @XmlElement(name = "NomeArquivo")
+    public String getDocName() {
+        return docName;
+    }
+
+    public void setDocName(String docName) {
+        this.docName = docName;
+    }
+
+    @XmlElement(name = "Observacao")
+    public String getObservation() {
+        return observation;
+    }
+
+    public void setObservation(String observation) {
+        this.observation = observation;
+    }
+
+    @XmlElement(name = "Destinatarios")
+    public String getRecipient() {
+        return recipient;
+    }
+
+    public void setRecipient(String recipient) {
+        this.recipient = recipient;
+    }
+
+    @XmlTransient
+    public CompanyModel getCompany() {
+        return company;
+    }
+
+    public void setCompany(CompanyModel company) {
+        this.company = company;
+    }
+
+    @XmlTransient
+    public byte[] getFilesBytes() {
+        return filesBytes;
+    }
+
+    public void setFilesBytes(byte[] filesBytes) {
+        this.filesBytes = filesBytes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ProtocolModel that)) return false;
+        return Objects.equals(ID, that.ID);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(ID);
+    }
+
+    @Override
+    public String toString() {
+        return "ProtocolModel{" +
+                "ID=" + ID +
+                ", date=" + date +
+                ", idetification='" + idetification + '\'' +
+                ", hash='" + hash + '\'' +
+                ", size=" + size +
+                ", docName='" + docName + '\'' +
+                ", observation='" + observation + '\'' +
+                ", recipient='" + recipient + '\'' +
+                ", company=" + company +
+                ", filesBytes=" + Arrays.toString(filesBytes) +
+                '}';
+    }
+}

--- a/src/main/java/org/devlouco/bacensenderhub/models/ProtocolModel.java
+++ b/src/main/java/org/devlouco/bacensenderhub/models/ProtocolModel.java
@@ -157,12 +157,81 @@ public class ProtocolModel {
         this.filesBytes = filesBytes;
     }
 
+    public static Builder builder(){
+        return new Builder();
+    }
+
+    public final static class Builder {
+
+
+        private Long ID;
+        private LocalDate date;
+        private String idetification;
+        private String hash;
+        private long size;
+        private String docName;
+        private String observation;
+        private String recipient;
+        private CompanyModel company;
+        private byte filesBytes[];
+
+        public Builder withID(Long ID) {
+            this.ID = ID;
+            return this;
+        }
+        public Builder withDate(LocalDate date) {
+            this.date = date;
+            return this;
+        }
+        public Builder withIdetification(String idetification) {
+            this.idetification = idetification;
+            return this;
+        }
+        public Builder withHash(String hash) {
+            this.hash = hash;
+            return this;
+        }
+        public Builder withSize(long size) {
+            this.size = size;
+            return this;
+        }
+        public Builder withDocName(String docName) {
+            this.docName = docName;
+            return this;
+        }
+        public Builder withObservation(String observation) {
+            this.observation = observation;
+            return this;
+        }
+        public Builder withRecipient(String recipient) {
+            this.recipient = recipient;
+            return this;
+        }
+        public Builder withCompany(CompanyModel company) {
+            this.company = company;
+            return this;
+        }
+        public Builder withFilesBytes(byte[] filesBytes) {
+            this.filesBytes = filesBytes;
+            return this;
+        }
+
+        public ProtocolModel build() {
+            return new ProtocolModel(
+                   ID,date,idetification,hash,size,docName,observation,recipient,company,filesBytes
+            );
+        }
+
+    }
+
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ProtocolModel that)) return false;
         return Objects.equals(ID, that.ID);
     }
+
 
     @Override
     public int hashCode() {
@@ -184,4 +253,6 @@ public class ProtocolModel {
                 ", filesBytes=" + Arrays.toString(filesBytes) +
                 '}';
     }
+
+
 }

--- a/src/main/java/org/devlouco/bacensenderhub/models/ProtocolResponseModel.java
+++ b/src/main/java/org/devlouco/bacensenderhub/models/ProtocolResponseModel.java
@@ -1,0 +1,113 @@
+package org.devlouco.bacensenderhub.models;
+
+import io.micrometer.core.instrument.binder.netty4.NettyAllocatorMetrics;
+import jakarta.persistence.*;
+import org.devlouco.bacensenderhub.services.exceptions.NotNullValidationService;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
+import java.util.Objects;
+
+@Entity
+@XmlRootElement(name = "Resultado")
+@XmlType(propOrder = {"protocol","linkContent"})
+public class ProtocolResponseModel {
+
+    private final String messageNotNull = "The Parameter cannot be null";
+    private final String messageBlank = "The Parameter cannot be null or empty";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ID;
+
+    private String protocol;
+
+
+    @Embedded
+    private LinkResponseModel linkContent;
+
+    @ManyToOne
+    @JoinColumn(name = "company_id")
+    private CompanyModel companyModel;
+
+    public ProtocolResponseModel(Long ID, String protocol, LinkResponseModel linkContent, CompanyModel companyModel) {
+        this.ID = ID;
+        this.protocol = protocol;
+        this.linkContent = linkContent;
+        this.companyModel = companyModel;
+    }
+
+    public ProtocolResponseModel() {}
+
+    public ProtocolResponseModel(String protocol, LinkResponseModel linkContent, CompanyModel companyModel) {
+        this.protocol = protocol;
+        this.linkContent = linkContent;
+        this.companyModel = companyModel;
+    }
+
+
+
+    @XmlTransient
+    public Long getID() {
+        return ID;
+    }
+
+    public void setID(Long ID) {
+        NotNullValidationService.notNull(ID,messageNotNull);
+        this.ID = ID;
+    }
+
+    @XmlElement(name = "Protocolo")
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        NotNullValidationService.notBlank(protocol,messageBlank);
+        this.protocol = protocol;
+    }
+
+    @XmlElement(name = "link", namespace = "http://www.w3.org/2005/Atom")
+    public LinkResponseModel getLinkContent() {
+        return linkContent;
+    }
+
+    public void setLinkContent(LinkResponseModel linkContent) {
+        NotNullValidationService.notBlank(linkContent,messageBlank);
+        this.linkContent = linkContent;
+    }
+
+    @XmlTransient
+    public CompanyModel getCompanyModel() {
+        return companyModel;
+    }
+
+    public void setCompanyModel(CompanyModel companyModel) {
+        NotNullValidationService.notNull(companyModel,messageNotNull);
+        this.companyModel = companyModel;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ProtocolResponseModel that)) return false;
+        return Objects.equals(ID, that.ID);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(ID);
+    }
+
+    @Override
+    public String toString() {
+        return "ProtocolResponseModel{" +
+                "ID=" + ID +
+                ", protocol='" + protocol + '\'' +
+                ", linkContent='" + linkContent + '\'' +
+                ", companyModel=" + companyModel +
+                '}';
+    }
+}

--- a/src/main/java/org/devlouco/bacensenderhub/models/ProtocolResponseModel.java
+++ b/src/main/java/org/devlouco/bacensenderhub/models/ProtocolResponseModel.java
@@ -89,6 +89,38 @@ public class ProtocolResponseModel {
         this.companyModel = companyModel;
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public final static class Builder{
+
+        private Long ID;
+        private String protocol;
+        private LinkResponseModel linkContent;
+        private CompanyModel companyModel;
+
+        public Builder withID(Long ID) {
+            this.ID = ID;
+            return this;
+        }
+        public Builder withProtocol(String protocol) {
+            this.protocol = protocol;
+            return this;
+        }
+        public Builder withLinkContent(LinkResponseModel linkContent) {
+            this.linkContent = linkContent;
+            return this;
+        }
+        public Builder withCompanyModel(CompanyModel companyModel) {
+            this.companyModel = companyModel;
+            return this;
+        }
+        public ProtocolResponseModel build() {
+            return new ProtocolResponseModel(ID, protocol, linkContent, companyModel);
+        }
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/org/devlouco/bacensenderhub/repositories/CompanyModelRepository.java
+++ b/src/main/java/org/devlouco/bacensenderhub/repositories/CompanyModelRepository.java
@@ -2,6 +2,14 @@ package org.devlouco.bacensenderhub.repositories;
 
 import org.devlouco.bacensenderhub.models.CompanyModel;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+@Repository
 public interface CompanyModelRepository extends JpaRepository<CompanyModel, Long> {
+    @Query("SELECT c FROM CompanyModel c where c.coop= :coop")
+    public Optional<CompanyModel> findByCoop(@Param("coop") int coop);
 }

--- a/src/main/java/org/devlouco/bacensenderhub/repositories/CompanyModelRepository.java
+++ b/src/main/java/org/devlouco/bacensenderhub/repositories/CompanyModelRepository.java
@@ -1,0 +1,7 @@
+package org.devlouco.bacensenderhub.repositories;
+
+import org.devlouco.bacensenderhub.models.CompanyModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompanyModelRepository extends JpaRepository<CompanyModel, Long> {
+}

--- a/src/main/java/org/devlouco/bacensenderhub/repositories/CredentialsModelRepository.java
+++ b/src/main/java/org/devlouco/bacensenderhub/repositories/CredentialsModelRepository.java
@@ -1,7 +1,17 @@
 package org.devlouco.bacensenderhub.repositories;
 
+import org.devlouco.bacensenderhub.models.CompanyModel;
 import org.devlouco.bacensenderhub.models.CredentialsModel;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+@Repository
 public interface CredentialsModelRepository extends JpaRepository<CredentialsModel, Long> {
+
+    @Query("SELECT c FROM CredentialsModel c where c.company.coop= :coop")
+    public Optional<CredentialsModel> findByCoop(@Param("coop") int coop);
 }

--- a/src/main/java/org/devlouco/bacensenderhub/repositories/CredentialsModelRepository.java
+++ b/src/main/java/org/devlouco/bacensenderhub/repositories/CredentialsModelRepository.java
@@ -1,0 +1,7 @@
+package org.devlouco.bacensenderhub.repositories;
+
+import org.devlouco.bacensenderhub.models.CredentialsModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CredentialsModelRepository extends JpaRepository<CredentialsModel, Long> {
+}

--- a/src/main/java/org/devlouco/bacensenderhub/repositories/ProtocolModelRepository.java
+++ b/src/main/java/org/devlouco/bacensenderhub/repositories/ProtocolModelRepository.java
@@ -1,0 +1,6 @@
+package org.devlouco.bacensenderhub.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProtocolModelRepository extends JpaRepository<ProtocolModelRepository, Integer> {
+}

--- a/src/main/java/org/devlouco/bacensenderhub/repositories/ProtocolModelRepository.java
+++ b/src/main/java/org/devlouco/bacensenderhub/repositories/ProtocolModelRepository.java
@@ -2,6 +2,8 @@ package org.devlouco.bacensenderhub.repositories;
 
 import org.devlouco.bacensenderhub.models.ProtocolModel;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ProtocolModelRepository extends JpaRepository<ProtocolModel, Long> {
 }

--- a/src/main/java/org/devlouco/bacensenderhub/repositories/ProtocolModelRepository.java
+++ b/src/main/java/org/devlouco/bacensenderhub/repositories/ProtocolModelRepository.java
@@ -1,6 +1,7 @@
 package org.devlouco.bacensenderhub.repositories;
 
+import org.devlouco.bacensenderhub.models.ProtocolModel;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProtocolModelRepository extends JpaRepository<ProtocolModelRepository, Integer> {
+public interface ProtocolModelRepository extends JpaRepository<ProtocolModel, Long> {
 }

--- a/src/main/java/org/devlouco/bacensenderhub/repositories/ProtocolResponseModelRepository.java
+++ b/src/main/java/org/devlouco/bacensenderhub/repositories/ProtocolResponseModelRepository.java
@@ -1,0 +1,9 @@
+package org.devlouco.bacensenderhub.repositories;
+
+import org.devlouco.bacensenderhub.models.ProtocolResponseModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProtocolResponseModelRepository extends JpaRepository<ProtocolResponseModel, Long> {
+}

--- a/src/main/java/org/devlouco/bacensenderhub/services/CompanyModelRepositoryService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/CompanyModelRepositoryService.java
@@ -1,0 +1,38 @@
+package org.devlouco.bacensenderhub.services;
+
+import org.devlouco.bacensenderhub.models.CompanyModel;
+import org.devlouco.bacensenderhub.repositories.CompanyModelRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+public class CompanyModelRepositoryService {
+
+    @Autowired
+    private CompanyModelRepository repo;
+
+    public CompanyModel save(CompanyModel companyModel){
+        Objects.requireNonNull(companyModel);
+        return repo.save(companyModel);
+    }
+
+    public CompanyModel update(CompanyModel companyModel){
+        Objects.requireNonNull(companyModel);
+        return repo.save(companyModel);
+    }
+    public CompanyModel findById(CompanyModel companyModel){
+        return repo.findById(companyModel.getID()).orElse(null);
+    }
+
+    public List<CompanyModel> findAll(){
+        return repo.findAll();
+    }
+
+    public void deleteById(CompanyModel companyModel){
+        repo.deleteById(companyModel.getID());
+    }
+
+}

--- a/src/main/java/org/devlouco/bacensenderhub/services/CompanyModelRepositoryService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/CompanyModelRepositoryService.java
@@ -7,7 +7,16 @@ import org.springframework.stereotype.Service;
 @Service
 public class CompanyModelRepositoryService extends GenericCrudService<CompanyModel, Long> {
 
+    private CompanyModelRepository repository;
+
     public CompanyModelRepositoryService(CompanyModelRepository repository) {
         super(repository);
+    }
+
+    public CompanyModel getCompanyModelByCoop(int coop) {
+
+        return this.repository.findByCoop(coop).orElseThrow(
+                () -> new RuntimeException("Could not find company model with coop " + coop)
+        );
     }
 }

--- a/src/main/java/org/devlouco/bacensenderhub/services/CompanyModelRepositoryService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/CompanyModelRepositoryService.java
@@ -2,37 +2,12 @@ package org.devlouco.bacensenderhub.services;
 
 import org.devlouco.bacensenderhub.models.CompanyModel;
 import org.devlouco.bacensenderhub.repositories.CompanyModelRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Objects;
-
 @Service
-public class CompanyModelRepositoryService {
+public class CompanyModelRepositoryService extends GenericCrudService<CompanyModel, Long> {
 
-    @Autowired
-    private CompanyModelRepository repo;
-
-    public CompanyModel save(CompanyModel companyModel){
-        Objects.requireNonNull(companyModel);
-        return repo.save(companyModel);
+    public CompanyModelRepositoryService(CompanyModelRepository repository) {
+        super(repository);
     }
-
-    public CompanyModel update(CompanyModel companyModel){
-        Objects.requireNonNull(companyModel);
-        return repo.save(companyModel);
-    }
-    public CompanyModel findById(CompanyModel companyModel){
-        return repo.findById(companyModel.getID()).orElse(null);
-    }
-
-    public List<CompanyModel> findAll(){
-        return repo.findAll();
-    }
-
-    public void deleteById(CompanyModel companyModel){
-        repo.deleteById(companyModel.getID());
-    }
-
 }

--- a/src/main/java/org/devlouco/bacensenderhub/services/CredentialsModelRepositoryService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/CredentialsModelRepositoryService.java
@@ -5,6 +5,7 @@ import org.devlouco.bacensenderhub.repositories.CredentialsModelRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 public class CredentialsModelRepositoryService {
@@ -13,18 +14,21 @@ public class CredentialsModelRepositoryService {
 
 
     public CredentialsModel save(CredentialsModel credentialsModel) {
+        Objects.requireNonNull(credentialsModel);
         return credentialsModelRepository.save(credentialsModel);
     }
 
     public CredentialsModel update(CredentialsModel credentialsModel) {
+        Objects.requireNonNull(credentialsModel);
         return credentialsModelRepository.save(credentialsModel);
     }
 
-    public CredentialsModel getCredentialsModel( CredentialsModel credentialsModel ) {
+    public CredentialsModel findCredentialsById(CredentialsModel credentialsModel ) {
+        Objects.requireNonNull(credentialsModel);
         return credentialsModelRepository.findById(credentialsModel.getID()).orElse(null);
     }
 
-    public List<CredentialsModel> getAllCredentialsModels() {
+    public List<CredentialsModel> findAllCredentials() {
         return credentialsModelRepository.findAll();
     }
 

--- a/src/main/java/org/devlouco/bacensenderhub/services/CredentialsModelRepositoryService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/CredentialsModelRepositoryService.java
@@ -4,37 +4,15 @@ import org.devlouco.bacensenderhub.models.CredentialsModel;
 import org.devlouco.bacensenderhub.repositories.CredentialsModelRepository;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Objects;
-
 @Service
-public class CredentialsModelRepositoryService {
-
-    private CredentialsModelRepository credentialsModelRepository;
+public class CredentialsModelRepositoryService extends GenericCrudService<CredentialsModel, Long> {
 
 
-    public CredentialsModel save(CredentialsModel credentialsModel) {
-        Objects.requireNonNull(credentialsModel);
-        return credentialsModelRepository.save(credentialsModel);
+    public CredentialsModelRepositoryService(CredentialsModelRepository credentialsModelRepository) {
+        super(credentialsModelRepository);
     }
 
-    public CredentialsModel update(CredentialsModel credentialsModel) {
-        Objects.requireNonNull(credentialsModel);
-        return credentialsModelRepository.save(credentialsModel);
-    }
 
-    public CredentialsModel findCredentialsById(CredentialsModel credentialsModel ) {
-        Objects.requireNonNull(credentialsModel);
-        return credentialsModelRepository.findById(credentialsModel.getID()).orElse(null);
-    }
-
-    public List<CredentialsModel> findAllCredentials() {
-        return credentialsModelRepository.findAll();
-    }
-
-    public void deleteCredentialsModel(CredentialsModel credentialsModel) {
-        credentialsModelRepository.delete(credentialsModel);
-    }
 
 
 }

--- a/src/main/java/org/devlouco/bacensenderhub/services/CredentialsModelRepositoryService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/CredentialsModelRepositoryService.java
@@ -1,0 +1,36 @@
+package org.devlouco.bacensenderhub.services;
+
+import org.devlouco.bacensenderhub.models.CredentialsModel;
+import org.devlouco.bacensenderhub.repositories.CredentialsModelRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CredentialsModelRepositoryService {
+
+    private CredentialsModelRepository credentialsModelRepository;
+
+
+    public CredentialsModel save(CredentialsModel credentialsModel) {
+        return credentialsModelRepository.save(credentialsModel);
+    }
+
+    public CredentialsModel update(CredentialsModel credentialsModel) {
+        return credentialsModelRepository.save(credentialsModel);
+    }
+
+    public CredentialsModel getCredentialsModel( CredentialsModel credentialsModel ) {
+        return credentialsModelRepository.findById(credentialsModel.getID()).orElse(null);
+    }
+
+    public List<CredentialsModel> getAllCredentialsModels() {
+        return credentialsModelRepository.findAll();
+    }
+
+    public void deleteCredentialsModel(CredentialsModel credentialsModel) {
+        credentialsModelRepository.delete(credentialsModel);
+    }
+
+
+}

--- a/src/main/java/org/devlouco/bacensenderhub/services/CredentialsModelRepositoryService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/CredentialsModelRepositoryService.java
@@ -7,9 +7,18 @@ import org.springframework.stereotype.Service;
 @Service
 public class CredentialsModelRepositoryService extends GenericCrudService<CredentialsModel, Long> {
 
+    private CredentialsModelRepository credentialsRepository;
 
     public CredentialsModelRepositoryService(CredentialsModelRepository credentialsModelRepository) {
+
         super(credentialsModelRepository);
+        this.credentialsRepository = credentialsModelRepository;
+    }
+
+    public CredentialsModel getCredentialsModelByCoop(int coop) {
+        return credentialsRepository.findByCoop(coop).orElseThrow(
+                () -> new RuntimeException("Could not find credentials with coop " + coop)
+        );
     }
 
 

--- a/src/main/java/org/devlouco/bacensenderhub/services/GenericCrudService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/GenericCrudService.java
@@ -1,0 +1,44 @@
+package org.devlouco.bacensenderhub.services;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public abstract class GenericCrudService<T, ID> {
+
+
+    protected final JpaRepository<T, ID> repository;
+
+
+    public GenericCrudService(final JpaRepository<T, ID> repository) {
+        this.repository = repository;
+    }
+
+    public T save(T entity) {
+        Objects.requireNonNull(entity);
+        return repository.save(entity);
+    }
+
+    public T update(T entity) {
+        Objects.requireNonNull(entity);
+        return repository.save(entity);
+    }
+
+    public Optional<T> findById(ID id) {
+        Objects.requireNonNull(id);
+        return repository.findById(id);
+    }
+
+    public List<T> findAll() {
+        return repository.findAll();
+    }
+
+    public void delete(T entity) {
+        Objects.requireNonNull(entity);
+        repository.delete(entity);
+    }
+
+
+}

--- a/src/main/java/org/devlouco/bacensenderhub/services/ProtocolFactoryService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/ProtocolFactoryService.java
@@ -1,0 +1,66 @@
+package org.devlouco.bacensenderhub.services;
+
+import org.devlouco.bacensenderhub.models.CompanyModel;
+import org.devlouco.bacensenderhub.models.ProtocolModel;
+import org.devlouco.bacensenderhub.util.Sha256Hash;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class ProtocolFactoryService {
+
+    private List<ProtocolModel> protocols;
+    private Sha256Hash sha256;
+    private CompanyModelRepositoryService companyModelRepository;
+
+    public ProtocolFactoryService(Sha256Hash sha256, CompanyModelRepositoryService companyModelRepositoryService) {
+        this.sha256 = sha256;
+        this.companyModelRepository = companyModelRepositoryService;
+    }
+
+    //Esse metodo implementa a logica de buscar os files no diretorio e apartir das informações do file
+    //ele faz o Builder do ProtocolModel, o formato do nome do file deve ser numero cooperativa_nomedoarquivo.extensão
+
+
+    public List<ProtocolModel> createAllFilesProtcol(String path, String identification) throws IOException {
+
+        protocols = new ArrayList<ProtocolModel>();
+        File file = new File(path);
+        if (file.exists()) {
+            for (File f : file.listFiles()) {
+                System.out.println(f.getName().substring(0,4));
+                if (f.isFile()) {
+                    System.out.println(f.getName().substring(0,3));
+                    CompanyModel companyModel = companyModelRepository.getCompanyModelByCoop(Integer.valueOf(f.getName().substring(0,4)));
+                    ProtocolModel protocol = ProtocolModel
+                            .builder()
+                            .withDate(LocalDate.now())
+                            .withIdetification(identification)
+                            .withHash(sha256.calcularHashSHA256(f))
+                            .withSize(f.length())
+                            .withDocName(f.getName())
+                            .withFilesBytes(getBytes(f))
+                            .withCompany(companyModel)
+                            .build();
+
+                    protocols.add(protocol);
+                }
+            }
+        }
+        return protocols;
+    }
+
+
+    public byte[] getBytes(File file) throws IOException {
+        return Files.readAllBytes(file.toPath());
+    }
+
+
+}

--- a/src/main/java/org/devlouco/bacensenderhub/services/ProtocolModelRepositoryService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/ProtocolModelRepositoryService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 public class ProtocolModelRepositoryService {
@@ -14,22 +15,26 @@ public class ProtocolModelRepositoryService {
     private ProtocolModelRepository repo;
 
     public ProtocolModel save(ProtocolModel protocolModel){
+        Objects.requireNonNull(protocolModel);
         return repo.save(protocolModel);
     }
 
     public ProtocolModel update(ProtocolModel protocolModel){
+        Objects.requireNonNull(protocolModel);
         return repo.save(protocolModel);
     }
 
     public void delete(ProtocolModel protocolModel){
+        Objects.requireNonNull(protocolModel);
         repo.delete(protocolModel);
     }
 
     public ProtocolModel findProtocolbyId(ProtocolModel protocolModel){
+        Objects.requireNonNull(protocolModel);
         return repo.findById(protocolModel.getID()).orElse(null);
     }
 
-    public List<ProtocolModel> findAllProtocol(ProtocolModel protocolModel){
+    public List<ProtocolModel> findAllProtocol(){
         return repo.findAll();
     }
 

--- a/src/main/java/org/devlouco/bacensenderhub/services/ProtocolModelRepositoryService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/ProtocolModelRepositoryService.java
@@ -1,0 +1,38 @@
+package org.devlouco.bacensenderhub.services;
+
+import org.devlouco.bacensenderhub.models.ProtocolModel;
+import org.devlouco.bacensenderhub.repositories.ProtocolModelRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ProtocolModelRepositoryService {
+
+    @Autowired
+    private ProtocolModelRepository repo;
+
+    public ProtocolModel save(ProtocolModel protocolModel){
+        return repo.save(protocolModel);
+    }
+
+    public ProtocolModel update(ProtocolModel protocolModel){
+        return repo.save(protocolModel);
+    }
+
+    public void delete(ProtocolModel protocolModel){
+        repo.delete(protocolModel);
+    }
+
+    public ProtocolModel findProtocolbyId(ProtocolModel protocolModel){
+        return repo.findById(protocolModel.getID()).orElse(null);
+    }
+
+    public List<ProtocolModel> findAllProtocol(ProtocolModel protocolModel){
+        return repo.findAll();
+    }
+
+
+
+}

--- a/src/main/java/org/devlouco/bacensenderhub/services/ProtocolModelRepositoryService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/ProtocolModelRepositoryService.java
@@ -2,40 +2,13 @@ package org.devlouco.bacensenderhub.services;
 
 import org.devlouco.bacensenderhub.models.ProtocolModel;
 import org.devlouco.bacensenderhub.repositories.ProtocolModelRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Objects;
-
 @Service
-public class ProtocolModelRepositoryService {
+public class ProtocolModelRepositoryService extends GenericCrudService<ProtocolModel, Long> {
 
-    @Autowired
-    private ProtocolModelRepository repo;
-
-    public ProtocolModel save(ProtocolModel protocolModel){
-        Objects.requireNonNull(protocolModel);
-        return repo.save(protocolModel);
-    }
-
-    public ProtocolModel update(ProtocolModel protocolModel){
-        Objects.requireNonNull(protocolModel);
-        return repo.save(protocolModel);
-    }
-
-    public void delete(ProtocolModel protocolModel){
-        Objects.requireNonNull(protocolModel);
-        repo.delete(protocolModel);
-    }
-
-    public ProtocolModel findProtocolbyId(ProtocolModel protocolModel){
-        Objects.requireNonNull(protocolModel);
-        return repo.findById(protocolModel.getID()).orElse(null);
-    }
-
-    public List<ProtocolModel> findAllProtocol(){
-        return repo.findAll();
+    public ProtocolModelRepositoryService(ProtocolModelRepository protocolModelRepository) {
+        super(protocolModelRepository);
     }
 
 

--- a/src/main/java/org/devlouco/bacensenderhub/services/ProtocolResponseModelService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/ProtocolResponseModelService.java
@@ -1,0 +1,14 @@
+package org.devlouco.bacensenderhub.services;
+
+
+import org.devlouco.bacensenderhub.models.ProtocolResponseModel;
+import org.devlouco.bacensenderhub.repositories.ProtocolResponseModelRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProtocolResponseModelService extends GenericCrudService<ProtocolResponseModel, Long> {
+
+    public ProtocolResponseModelService(ProtocolResponseModelRepository repository) {
+        super(repository);
+    }
+}

--- a/src/main/java/org/devlouco/bacensenderhub/services/StaXmlService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/StaXmlService.java
@@ -1,0 +1,64 @@
+package org.devlouco.bacensenderhub.services;
+
+import org.devlouco.bacensenderhub.models.ProtocolModel;
+import org.devlouco.bacensenderhub.models.ProtocolResponseModel;
+import org.devlouco.bacensenderhub.services.exceptions.NotNullValidationService;
+import org.springframework.stereotype.Service;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+@Service
+public class StaXmlService {
+
+
+    public String marshalProtocol(ProtocolModel protocol) {
+        NotNullValidationService.notNull(protocol, "Protocol cannot be null");
+
+        try{
+            JAXBContext jaxbContext = JAXBContext.newInstance(ProtocolModel.class);
+            Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
+            jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+            StringWriter stringWriter = new StringWriter();
+            jaxbMarshaller.marshal(protocol, stringWriter);
+            return stringWriter.toString();
+        }catch(Exception e){
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    public ProtocolModel unmarshalProtocol(String xml){
+        NotNullValidationService.notNull(xml, "Protocol cannot be null");
+        try {
+            JAXBContext jaxbContext = JAXBContext.newInstance(ProtocolModel.class);
+            Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+            StringReader stringReader = new StringReader(xml);
+            return (ProtocolModel) jaxbUnmarshaller.unmarshal(stringReader);
+        }catch(Exception e){
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    public ProtocolResponseModel unmarshalProtocolResponse(String xml){
+        NotNullValidationService.notNull(xml, "Protocol cannot be null");
+
+        try {
+            JAXBContext jaxbContext = JAXBContext.newInstance(ProtocolResponseModel.class);
+            Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+            StringReader stringReader = new StringReader(xml);
+            return (ProtocolResponseModel) jaxbUnmarshaller.unmarshal(stringReader);
+        }catch(Exception e){
+            throw new RuntimeException(e);
+        }
+
+
+    }
+
+}
+
+

--- a/src/main/java/org/devlouco/bacensenderhub/services/WebServiceSenderClient.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/WebServiceSenderClient.java
@@ -1,0 +1,96 @@
+package org.devlouco.bacensenderhub.services;
+
+import org.devlouco.bacensenderhub.models.CredentialsModel;
+import org.devlouco.bacensenderhub.models.ProtocolModel;
+import org.devlouco.bacensenderhub.models.ProtocolResponseModel;
+import org.devlouco.bacensenderhub.util.headerStrategy.BacenHeader;
+import org.devlouco.bacensenderhub.util.headerStrategy.HeaderFileUpload;
+import org.devlouco.bacensenderhub.util.headerStrategy.HeaderProtocol;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Service
+public class WebServiceSenderClient{
+
+    private String PROTOCOL_URI = "https://sta-h.bcb.gov.br/staws/arquivos/";
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    private StaXmlService staXmlService;
+
+    private ApplicationContext applicationContext;
+
+    private WebClient webClient;
+
+    private BacenHeader bacenHeader;
+
+    private ProtocolFactoryService protocolFactoryService;
+    private CredentialsModelRepositoryService credentialsModelRepositoryService;
+
+
+    public WebServiceSenderClient(StaXmlService staXmlService, ApplicationContext applicationContext, ProtocolFactoryService protocolFactoryService, CredentialsModelRepositoryService credentialsModelRepositoryService) {
+
+        this.staXmlService = staXmlService;
+        this.applicationContext = applicationContext;
+        this.webClient = WebClient.builder()
+                .build();
+        this.protocolFactoryService = protocolFactoryService;
+         this.credentialsModelRepositoryService = credentialsModelRepositoryService;
+    }
+
+    public void setURI(String uri){
+        this.PROTOCOL_URI = uri;
+    }
+
+    //metodo resposanvel por fazer uma iteração na lista de protocolModel e passar para o metodo CreateProtocol fazer o envio async
+
+    public Flux<ProtocolResponseModel> createProtocols(List<ProtocolModel> protocolModels) {
+
+        return Flux.fromIterable(protocolModels)
+                .flatMap(protocolModel -> {
+                    CredentialsModel credentialsModel = credentialsModelRepositoryService.getCredentialsModelByCoop(protocolModel.getCompany().getCoop());
+                    return createProtocol(protocolModel, credentialsModel);
+                });
+    }
+
+
+    //metodo responsavel por fazer a requisição do protocolo ao webService do Bacen
+
+    public Mono<ProtocolResponseModel> createProtocol(ProtocolModel protocolModel, CredentialsModel credentialsModel) {
+
+        bacenHeader = applicationContext.getBean(HeaderProtocol.class, BacenHeader.class);
+
+        return webClient.post()
+                .uri(PROTOCOL_URI)
+                .headers(headers -> headers.addAll(bacenHeader.getHeader(credentialsModel)))
+                .bodyValue(staXmlService.marshalProtocol(protocolModel))
+                .retrieve()
+                .bodyToMono(String.class) // WebClient retorna Mono<String>
+                .map(response -> staXmlService.unmarshalProtocolResponse(response.trim()));
+    }
+
+
+    public ResponseEntity<String> uploadFile(String protocol, byte[] content, CredentialsModel credentialsModel) throws Exception {
+        bacenHeader = applicationContext.getBean(HeaderFileUpload.class,BacenHeader.class);
+        HttpEntity<byte[]> request = new HttpEntity<>(content, bacenHeader.getHeader(credentialsModel));
+        ResponseEntity<String> response = restTemplate.exchange(PROTOCOL_URI + protocol, HttpMethod.PUT, request, String.class);
+        return response;
+
+    }
+
+
+}

--- a/src/main/java/org/devlouco/bacensenderhub/services/exceptions/NotNullValidationService.java
+++ b/src/main/java/org/devlouco/bacensenderhub/services/exceptions/NotNullValidationService.java
@@ -1,0 +1,22 @@
+package org.devlouco.bacensenderhub.services.exceptions;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotNullValidationService {
+
+    public static <T> void notNull(T object, String message){
+        if(object == null){
+            throw new IllegalArgumentException(message);
+
+        }
+    }
+
+    public static <T> void notBlank(T object, String message){
+        if(object == null || object.equals("")){
+            throw new IllegalArgumentException(message);
+
+        }
+    }
+
+}

--- a/src/main/java/org/devlouco/bacensenderhub/util/BasicAuth.java
+++ b/src/main/java/org/devlouco/bacensenderhub/util/BasicAuth.java
@@ -1,0 +1,20 @@
+package org.devlouco.bacensenderhub.util;
+
+import org.devlouco.bacensenderhub.models.CredentialsModel;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Component
+public class BasicAuth {
+
+    public String createBasicAuthHeader(CredentialsModel credentials) {
+        String auth = credentials.getLogin() + ":" + credentials.getPassword();
+        String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+        return "Basic " + encodedAuth;
+    }
+
+
+
+}

--- a/src/main/java/org/devlouco/bacensenderhub/util/Sha256Hash.java
+++ b/src/main/java/org/devlouco/bacensenderhub/util/Sha256Hash.java
@@ -1,0 +1,46 @@
+package org.devlouco.bacensenderhub.util;
+
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@Component
+public class Sha256Hash {
+
+
+    //metodo para calcular o hash sha256, cuidado sem esse metodo o envio não funciona
+
+    public String calcularHashSHA256(File file) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] buffer = new byte[4096];
+            FileInputStream fis = new FileInputStream(file);
+
+            int bytesRead;
+            while ((bytesRead = fis.read(buffer)) != -1) {
+                digest.update(buffer, 0, bytesRead);
+            }
+
+            fis.close();
+
+            byte[] hashBytes = digest.digest();
+
+            // Converter o array de bytes em uma representação hexadecimal
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hashBytes) {
+                String hex = String.format("%02x", b);
+                hexString.append(hex);
+            }
+
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException | IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/org/devlouco/bacensenderhub/util/headerStrategy/BacenHeader.java
+++ b/src/main/java/org/devlouco/bacensenderhub/util/headerStrategy/BacenHeader.java
@@ -1,0 +1,11 @@
+package org.devlouco.bacensenderhub.util.headerStrategy;
+
+import org.devlouco.bacensenderhub.models.CredentialsModel;
+import org.springframework.http.HttpHeaders;
+
+public interface BacenHeader {
+
+    public HttpHeaders getHeader(CredentialsModel credentialsModel);
+
+
+}

--- a/src/main/java/org/devlouco/bacensenderhub/util/headerStrategy/HeaderFileUpload.java
+++ b/src/main/java/org/devlouco/bacensenderhub/util/headerStrategy/HeaderFileUpload.java
@@ -21,7 +21,7 @@ public class HeaderFileUpload implements BacenHeader{
     public HttpHeaders getHeader(CredentialsModel credentialsModel) {
         headers = new HttpHeaders();
         headers.add("Authorization", basicAuth.createBasicAuthHeader(credentialsModel));
-        headers.add("Content-Type", "application/xml");
+        headers.add("Content-Type", "application/octet-stream");
 
         return headers;
     }

--- a/src/main/java/org/devlouco/bacensenderhub/util/headerStrategy/HeaderFileUpload.java
+++ b/src/main/java/org/devlouco/bacensenderhub/util/headerStrategy/HeaderFileUpload.java
@@ -1,0 +1,28 @@
+package org.devlouco.bacensenderhub.util.headerStrategy;
+
+
+import org.devlouco.bacensenderhub.models.CredentialsModel;
+import org.devlouco.bacensenderhub.util.BasicAuth;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HeaderFileUpload implements BacenHeader{
+
+    private HttpHeaders headers;
+
+    private BasicAuth basicAuth;
+
+    public HeaderFileUpload(BasicAuth basicAuth) {
+        this.basicAuth = basicAuth;
+    }
+
+    @Override
+    public HttpHeaders getHeader(CredentialsModel credentialsModel) {
+        headers = new HttpHeaders();
+        headers.add("Authorization", basicAuth.createBasicAuthHeader(credentialsModel));
+        headers.add("Content-Type", "application/xml");
+
+        return headers;
+    }
+}

--- a/src/main/java/org/devlouco/bacensenderhub/util/headerStrategy/HeaderProtocol.java
+++ b/src/main/java/org/devlouco/bacensenderhub/util/headerStrategy/HeaderProtocol.java
@@ -1,0 +1,25 @@
+package org.devlouco.bacensenderhub.util.headerStrategy;
+
+import org.devlouco.bacensenderhub.models.CredentialsModel;
+import org.devlouco.bacensenderhub.util.BasicAuth;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HeaderProtocol implements BacenHeader{
+
+    private HttpHeaders headers;
+    private BasicAuth basicAuth;
+    public HeaderProtocol(BasicAuth basicAuth) {
+        this.basicAuth = basicAuth;
+        this.headers = new HttpHeaders();
+    }
+
+    @Override
+    public HttpHeaders getHeader(CredentialsModel credentialsModel) {
+        headers.add("Authorization", basicAuth.createBasicAuthHeader(credentialsModel));
+        headers.add("Content-Type", "application/xml");
+
+        return headers;
+    }
+}

--- a/src/test/java/org/devlouco/bacensenderhub/models/CompanyModelTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/models/CompanyModelTest.java
@@ -1,0 +1,74 @@
+package org.devlouco.bacensenderhub.models;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CompanyModelTest {
+
+    private CompanyModel company;
+    private Validator validator;
+
+
+    @BeforeEach
+    void setup(){
+
+        company = new CompanyModel(2037,"90801765901272");
+        company.setID(1l);
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+
+    }
+
+    @Test
+    void Dado_a_criacao_do_objeto_Quando_atribuir_a_coop_Entao_nao_deve_lancar_exception(){
+        assertDoesNotThrow(()->company.getCoop());
+    }
+    @Test
+    void Dado_a_criacao_do_objeto_Quando_nao_atribuir_a_coop_Entao_deve_lancar_exception(){
+        Integer inte = null;
+        assertThrows(NullPointerException.class, () -> company.setCoop(inte.intValue()));
+    }
+
+    @Test
+    void Dado_a_criacao_do_objeto_Quando_atribuir_a_cnpj_Entao_nao_deve_lancar_exception(){
+        assertDoesNotThrow(()->company.getCnpj());
+    }
+    @Test
+    void Dado_a_criacao_do_objeto_Quando_nao_atribuir_a_cnpj_Entao_deve_lancar_exception(){
+        String cnpj = null;
+        assertThrows(NullPointerException.class, () -> company.setCnpj(cnpj));
+    }
+
+    @Test
+    void Dado_a_criacao_do_objeto_Quando_atribuir_uma_string_Entao_nao_deve_ser_em_branco(){
+        String cnpjBranco = "";
+        company.setCnpj(cnpjBranco);
+        Set<ConstraintViolation<CompanyModel>> validate = validator.validate(company);
+        assertFalse(validate.isEmpty());
+    }
+
+    @Test
+    void Dado_a_criacao_do_objeto_Quando_atribuir_uma_string_Entao_nao_deve_ter_mais_que_quartoze_digitos(){
+        String cnpjBranco = "0906080608050406";
+        company.setCnpj(cnpjBranco);
+        Set<ConstraintViolation<CompanyModel>> validate = validator.validate(company);
+        assertFalse(validate.isEmpty());
+    }
+
+    @Test
+    void Dado_a_criacao_do_objeto_Quando_atribuir_uma_coop_Entao_nao_deve_ter_mais_que_quatro_digitos(){
+        int coop = 90102;
+        company.setCoop(coop);
+        Set<ConstraintViolation<CompanyModel>> validate = validator.validate(company);
+        assertFalse(validate.isEmpty());
+    }
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/models/CredentialsModelTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/models/CredentialsModelTest.java
@@ -1,0 +1,47 @@
+package org.devlouco.bacensenderhub.models;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class CredentialsModelTest {
+
+    @Mock
+    private CompanyModel company;
+    @InjectMocks
+    private CredentialsModel credentials;
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        credentials.setLogin("teste");
+        credentials.setPassword("password");
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    }
+
+    @Test
+    void Dado_um_objeto_Quando_instanciado_com_atributos_Entao_nao_deve_ser_nullo(){
+        Set<ConstraintViolation<CredentialsModel>> validate = validator.validate(credentials);
+        assertFalse(!validate.isEmpty());
+    }
+
+    @Test
+    void Dado_um_objeto_Quando_os_atribuido_forem_null_Entao_deve_lancar_exception(){
+        credentials.setLogin(null);
+        Set<ConstraintViolation<CredentialsModel>> validate = validator.validate(credentials);
+        assertTrue(!validate.isEmpty());
+    }
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/models/ProtocolModelTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/models/ProtocolModelTest.java
@@ -39,20 +39,20 @@ class ProtocolModelTest {
     }
 
     @Test
-    void Dado_um_objeto_instanciado_valido_Quando_atribuido_um_valor_nulo_Entao_nao_deve_lancar_exception(){
+    void Dado_um_objeto_instanciado_Quando_atribuido_um_valor_nulo_Entao_nao_deve_lancar_exception(){
         Set<ConstraintViolation<ProtocolModel>> validate = validator.validate(protocolModel);
         assertFalse(validate.isEmpty());
     }
 
     @Test
-    void Dado_um_objeto_instanciado_valido_Quando_atribuido_um_valor_nulo_Entao_deve_lancar_exception(){
+    void Dado_um_objeto_instanciado_Quando_atribuido_um_valor_nulo_Entao_deve_lancar_exception(){
         protocolModel.setDate(null);
         Set<ConstraintViolation<ProtocolModel>> validate = validator.validate(protocolModel);
         assertTrue(!validate.isEmpty());
     }
 
     @Test
-    void Dado_um_objeto_instanciado_valido_Quando_atribuido_o_hash_Entao_deve_conter_sessenta_e_quatro_digitos(){
+    void Dado_um_objeto_instanciado_Quando_atribuido_o_hash_Entao_deve_conter_sessenta_e_quatro_digitos(){
         protocolModel.setHash("9179ec02b930c1bd44744d784680b21f6ebcb4c1fccbfe1a5bc0f64df7559d585649874");
         protocolModel.setCompany(
                 new CompanyModel(4010,"90102748374658")

--- a/src/test/java/org/devlouco/bacensenderhub/models/ProtocolModelTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/models/ProtocolModelTest.java
@@ -1,0 +1,65 @@
+package org.devlouco.bacensenderhub.models;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProtocolModelTest {
+
+    @Mock
+    private CompanyModel companyModel;
+
+    private ProtocolModel protocolModel;
+    @Mock
+    private byte[] fileByte;
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+
+        protocolModel = new ProtocolModel(
+                1l, LocalDate.now(), "4010","9179ec02b930c1bd44744d784680b21f6ebcb4c1fccbfe1a5bc0f64df7559d58",
+                256,"terste.zip","","544",companyModel,fileByte);
+
+
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    }
+
+    @Test
+    void Dado_um_objeto_instanciado_valido_Quando_atribuido_um_valor_nulo_Entao_nao_deve_lancar_exception(){
+        Set<ConstraintViolation<ProtocolModel>> validate = validator.validate(protocolModel);
+        assertFalse(validate.isEmpty());
+    }
+
+    @Test
+    void Dado_um_objeto_instanciado_valido_Quando_atribuido_um_valor_nulo_Entao_deve_lancar_exception(){
+        protocolModel.setDate(null);
+        Set<ConstraintViolation<ProtocolModel>> validate = validator.validate(protocolModel);
+        assertTrue(!validate.isEmpty());
+    }
+
+    @Test
+    void Dado_um_objeto_instanciado_valido_Quando_atribuido_o_hash_Entao_deve_conter_sessenta_e_quatro_digitos(){
+        protocolModel.setHash("9179ec02b930c1bd44744d784680b21f6ebcb4c1fccbfe1a5bc0f64df7559d585649874");
+        protocolModel.setCompany(
+                new CompanyModel(4010,"90102748374658")
+        );
+        Set<ConstraintViolation<ProtocolModel>> validate = validator.validate(protocolModel);
+        String mensagem = validate.stream().findFirst().get().getMessage();
+        assertEquals("tamanho deve ser entre 0 e 64", mensagem);
+    }
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/models/ProtocolResponseModelTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/models/ProtocolResponseModelTest.java
@@ -1,0 +1,50 @@
+package org.devlouco.bacensenderhub.models;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProtocolResponseModelTest {
+
+    @Mock
+    private CompanyModel companyModel;
+    private ProtocolResponseModel protocolResponseModel;
+
+    @Mock
+    private LinkResponseModel linkResponseModel;
+
+    @BeforeEach
+    void setUp() {
+        protocolResponseModel = new ProtocolResponseModel("9010830"
+                ,linkResponseModel,
+                companyModel
+        );
+    }
+
+    @Test
+    void Dado_uma_instacia_de_protocolResponseModel_Quando_os_atributos_forem_nulos_Entao_deve_lancar_exception(){
+
+        IllegalArgumentException illegalArgumentExceptionId = assertThrows(IllegalArgumentException.class, () -> protocolResponseModel.setID(null));
+        assertEquals("The Parameter cannot be null", illegalArgumentExceptionId.getMessage());
+    }
+
+    @Test
+    void Dado_uma_instacia_de_protocolResponseModel_Quando_os_atributos_forem_nulos_ou_empty_Entao_deve_lancar_exception(){
+
+        assertAll(()->{
+            IllegalArgumentException illegalArgumentExceptionProtocolNull = assertThrows(IllegalArgumentException.class, () -> protocolResponseModel.setProtocol(null));
+            assertEquals("The Parameter cannot be null or empty", illegalArgumentExceptionProtocolNull.getMessage());
+
+            IllegalArgumentException illegalArgumentExceptionProtocolEmpty = assertThrows(IllegalArgumentException.class, () -> protocolResponseModel.setProtocol(""));
+            assertEquals("The Parameter cannot be null or empty", illegalArgumentExceptionProtocolEmpty.getMessage());
+
+        });
+
+
+    }
+
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/services/CompanyModelRepositoryServiceTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/CompanyModelRepositoryServiceTest.java
@@ -3,6 +3,7 @@ package org.devlouco.bacensenderhub.services;
 import org.devlouco.bacensenderhub.models.CompanyModel;
 import org.devlouco.bacensenderhub.models.CredentialsModel;
 import org.devlouco.bacensenderhub.repositories.CompanyModelRepository;
+import org.devlouco.bacensenderhub.util.TestDataFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,87 +21,28 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class CompanyModelRepositoryServiceTest {
+class CompanyModelRepositoryServiceTest extends GenericCrudServiceTest < CompanyModel, Long>{
 
     @Mock
-    private CompanyModelRepository repo;
-    @InjectMocks
-    private CompanyModelRepositoryService service;
+    private CompanyModelRepository repository;
 
-    private CompanyModel companyModel;
     private CredentialsModel credentialsModel;
+
+
+    @Override
+    protected CompanyModel createEntity() {
+
+        return TestDataFactory.createCompanyModel().build();
+
+    }
 
     @BeforeEach
     void setUp() {
-
-        credentialsModel = mock(CredentialsModel.class);
-
-        companyModel = new CompanyModel(1l,9010,"90203020102019",credentialsModel);
-
-
-
+        super.setUp();
+        genericCrudService = new CompanyModelRepositoryService(repository);
+        jpaRepository = repository;
+        id = 1l;
     }
 
-    @Test
-    void Dado_uma_entidade_valida_Quando_salvar_Entao_salva_a_entidade(){
-        when(repo.save(any(CompanyModel.class))).thenReturn(
-                companyModel
-        );
-
-        assertEquals(companyModel, service.save(companyModel));
-    }
-
-    @Test
-    void Dado_uma_entidade_valida_Quando_tentar_salvar_nulo_Entao_deve_lancar_exception(){
-        assertThrows(NullPointerException.class, () -> service.save(null));
-       verify(repo, never()).save(any(CompanyModel.class));
-    }
-
-    @Test
-    void Dado_uma_entidade_valida_Quando_feito_update_Entao_retorna_a_entidade(){
-        when(repo.save(any(CompanyModel.class))).thenReturn(
-                companyModel
-        );
-
-        CompanyModel update = service.update(companyModel);
-
-        assertEquals(companyModel, update);
-        verify(repo, times(1)).save(any(CompanyModel.class));
-
-    }
-
-    @Test
-    void Dado_uma_entidade_valida_Quando_chamado_findById_Entao_retorna_uma_entidade(){
-        when(repo.findById(anyLong())).thenReturn(
-                Optional.of(companyModel)
-        );
-
-        CompanyModel byId = service.findById(companyModel.getID()).orElse(null);
-        assertAll(
-                ()->{
-                    assertNotNull(byId);
-                    assertEquals(companyModel, byId);
-                    verify(repo, times(1)).findById(anyLong());
-                }
-        );
-
-
-    }
-
-    @Test
-    void Dado_uma_entidade_valida_Quando_chamado_findAll_Entao_retorna_uma_lista_de_entidade(){
-        when(repo.findAll()).thenReturn(
-                List.of(companyModel)
-        );
-
-        List<CompanyModel> all = service.findAll();
-        assertAll(
-                ()->{
-                    assertNotNull(all);
-                    assertEquals(1, all.size());
-                    verify(repo, times(1)).findAll();
-                }
-        );
-    }
 
 }

--- a/src/test/java/org/devlouco/bacensenderhub/services/CompanyModelRepositoryServiceTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/CompanyModelRepositoryServiceTest.java
@@ -5,10 +5,12 @@ import org.devlouco.bacensenderhub.models.CredentialsModel;
 import org.devlouco.bacensenderhub.repositories.CompanyModelRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,6 +18,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class CompanyModelRepositoryServiceTest {
 
 

--- a/src/test/java/org/devlouco/bacensenderhub/services/CompanyModelRepositoryServiceTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/CompanyModelRepositoryServiceTest.java
@@ -21,18 +21,17 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class CompanyModelRepositoryServiceTest {
 
-
-    @InjectMocks
-    private CompanyModelRepositoryService service;
     @Mock
     private CompanyModelRepository repo;
+    @InjectMocks
+    private CompanyModelRepositoryService service;
+
     private CompanyModel companyModel;
     private CredentialsModel credentialsModel;
 
     @BeforeEach
     void setUp() {
 
-        MockitoAnnotations.openMocks(this);
         credentialsModel = mock(CredentialsModel.class);
 
         companyModel = new CompanyModel(1l,9010,"90203020102019",credentialsModel);
@@ -75,7 +74,7 @@ class CompanyModelRepositoryServiceTest {
                 Optional.of(companyModel)
         );
 
-        CompanyModel byId = service.findById(companyModel);
+        CompanyModel byId = service.findById(companyModel.getID()).orElse(null);
         assertAll(
                 ()->{
                     assertNotNull(byId);

--- a/src/test/java/org/devlouco/bacensenderhub/services/CompanyModelRepositoryServiceTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/CompanyModelRepositoryServiceTest.java
@@ -1,0 +1,103 @@
+package org.devlouco.bacensenderhub.services;
+
+import org.devlouco.bacensenderhub.models.CompanyModel;
+import org.devlouco.bacensenderhub.models.CredentialsModel;
+import org.devlouco.bacensenderhub.repositories.CompanyModelRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CompanyModelRepositoryServiceTest {
+
+
+    @InjectMocks
+    private CompanyModelRepositoryService service;
+    @Mock
+    private CompanyModelRepository repo;
+    private CompanyModel companyModel;
+    private CredentialsModel credentialsModel;
+
+    @BeforeEach
+    void setUp() {
+
+        MockitoAnnotations.openMocks(this);
+        credentialsModel = mock(CredentialsModel.class);
+
+        companyModel = new CompanyModel(1l,9010,"90203020102019",credentialsModel);
+
+
+
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_salvar_Entao_salva_a_entidade(){
+        when(repo.save(any(CompanyModel.class))).thenReturn(
+                companyModel
+        );
+
+        assertEquals(companyModel, service.save(companyModel));
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_tentar_salvar_nulo_Entao_deve_lancar_exception(){
+        assertThrows(NullPointerException.class, () -> service.save(null));
+       verify(repo, never()).save(any(CompanyModel.class));
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_feito_update_Entao_retorna_a_entidade(){
+        when(repo.save(any(CompanyModel.class))).thenReturn(
+                companyModel
+        );
+
+        CompanyModel update = service.update(companyModel);
+
+        assertEquals(companyModel, update);
+        verify(repo, times(1)).save(any(CompanyModel.class));
+
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_chamado_findById_Entao_retorna_uma_entidade(){
+        when(repo.findById(anyLong())).thenReturn(
+                Optional.of(companyModel)
+        );
+
+        CompanyModel byId = service.findById(companyModel);
+        assertAll(
+                ()->{
+                    assertNotNull(byId);
+                    assertEquals(companyModel, byId);
+                    verify(repo, times(1)).findById(anyLong());
+                }
+        );
+
+
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_chamado_findAll_Entao_retorna_uma_lista_de_entidade(){
+        when(repo.findAll()).thenReturn(
+                List.of(companyModel)
+        );
+
+        List<CompanyModel> all = service.findAll();
+        assertAll(
+                ()->{
+                    assertNotNull(all);
+                    assertEquals(1, all.size());
+                    verify(repo, times(1)).findAll();
+                }
+        );
+    }
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/services/CredentialsModelRepositoryServiceTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/CredentialsModelRepositoryServiceTest.java
@@ -1,0 +1,109 @@
+package org.devlouco.bacensenderhub.services;
+
+import org.devlouco.bacensenderhub.models.CompanyModel;
+import org.devlouco.bacensenderhub.models.CredentialsModel;
+import org.devlouco.bacensenderhub.repositories.CredentialsModelRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class CredentialsModelRepositoryServiceTest {
+
+    @Mock
+    private CredentialsModelRepository repo;
+
+    @InjectMocks
+    private CredentialsModelRepositoryService service;
+
+    private CredentialsModel credentialsModel;
+
+    @BeforeEach
+    void setup(){
+        CompanyModel companyModel = new CompanyModel(3027,"90301720193847");
+        credentialsModel = new CredentialsModel(
+                1l,"teste","teste",companyModel
+        );
+
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_salvar_Entao_retorna_uma_entidade(){
+        when(repo.save(any())).thenReturn(
+                credentialsModel
+        );
+
+        CredentialsModel save = service.save(credentialsModel);
+        assertAll(
+                ()->{
+                    assertNotNull(save);
+                    assertEquals(credentialsModel,save);
+                    verify(repo, times(1)).save(any());
+                }
+        );
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_tentar_salvar_nulo_Entao_deve_lancar_exception(){
+        assertThrows(NullPointerException.class, () ->service.save(null));
+
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_feito_o_update_Entao_deve_retornar_a_entidade(){
+        when(repo.save(any())).thenReturn(
+                credentialsModel
+        );
+
+        CredentialsModel update = service.update(credentialsModel);
+        assertAll(
+                ()->{
+                    assertNotNull(update);
+                    assertEquals(credentialsModel, update);
+                    verify(repo,times(1)).save(any());
+                }
+        );
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_feito_o_getCredentialsModel_Entao_deve_retornar_a_entidade(){
+        when(repo.findById(anyLong())).thenReturn(
+                Optional.of(credentialsModel)
+        );
+
+        CredentialsModel update = service.findCredentialsById(credentialsModel);
+        assertAll(
+                ()->{
+                    assertNotNull(update);
+                    assertEquals(1l,update.getID());
+                    verify(repo,times(1)).findById(anyLong());
+                }
+        );
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_chamado_findAll_Credentials_Entao_retorna_uma_lista_de_entidade(){
+        when(repo.findAll()).thenReturn(
+                List.of(credentialsModel)
+        );
+
+        List<CredentialsModel> all = service.findAllCredentials();
+        assertAll(
+                ()->{
+                    assertNotNull(all);
+                    assertEquals(1, all.size());
+                    verify(repo, times(1)).findAll();
+                }
+        );
+    }
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/services/CredentialsModelRepositoryServiceTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/CredentialsModelRepositoryServiceTest.java
@@ -3,6 +3,7 @@ package org.devlouco.bacensenderhub.services;
 import org.devlouco.bacensenderhub.models.CompanyModel;
 import org.devlouco.bacensenderhub.models.CredentialsModel;
 import org.devlouco.bacensenderhub.repositories.CredentialsModelRepository;
+import org.devlouco.bacensenderhub.util.TestDataFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,93 +18,27 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
-class CredentialsModelRepositoryServiceTest {
+class CredentialsModelRepositoryServiceTest extends GenericCrudServiceTest<CredentialsModel, Long>{
 
     @Mock
     private CredentialsModelRepository repo;
 
-    @InjectMocks
-    private CredentialsModelRepositoryService service;
 
-    private CredentialsModel credentialsModel;
+    @Override
+    protected CredentialsModel createEntity() {
+        return TestDataFactory.createCredentialsModel()
+                .withID(1l)
+                .build();
+    }
 
     @BeforeEach
     void setup(){
-        CompanyModel companyModel = new CompanyModel(3027,"90301720193847");
-        credentialsModel = new CredentialsModel(
-                1l,"teste","teste",companyModel
-        );
-
+        super.setUp();
+        jpaRepository = repo;
+        genericCrudService = new CredentialsModelRepositoryService(repo);
+        id = entity.getID();
     }
 
-    @Test
-    void Dado_uma_entidade_valida_Quando_salvar_Entao_retorna_uma_entidade(){
-        when(repo.save(any())).thenReturn(
-                credentialsModel
-        );
 
-        CredentialsModel save = service.save(credentialsModel);
-        assertAll(
-                ()->{
-                    assertNotNull(save);
-                    assertEquals(credentialsModel,save);
-                    verify(repo, times(1)).save(any());
-                }
-        );
-    }
-
-    @Test
-    void Dado_uma_entidade_valida_Quando_tentar_salvar_nulo_Entao_deve_lancar_exception(){
-        assertThrows(NullPointerException.class, () ->service.save(null));
-
-    }
-
-    @Test
-    void Dado_uma_entidade_valida_Quando_feito_o_update_Entao_deve_retornar_a_entidade(){
-        when(repo.save(any())).thenReturn(
-                credentialsModel
-        );
-
-        CredentialsModel update = service.update(credentialsModel);
-        assertAll(
-                ()->{
-                    assertNotNull(update);
-                    assertEquals(credentialsModel, update);
-                    verify(repo,times(1)).save(any());
-                }
-        );
-    }
-
-    @Test
-    void Dado_uma_entidade_valida_Quando_feito_o_findByID_Entao_deve_retornar_a_entidade(){
-        when(repo.findById(anyLong())).thenReturn(
-                Optional.of(credentialsModel)
-        );
-
-        CredentialsModel update = service.findById(credentialsModel.getID()).orElse(null);
-        assertAll(
-                ()->{
-                    assertNotNull(update);
-                    assertEquals(1l,update.getID());
-                    verify(repo,times(1)).findById(anyLong());
-                }
-        );
-    }
-
-    @Test
-    void Dado_uma_entidade_valida_Quando_chamado_findAll_Credentials_Entao_retorna_uma_lista_de_entidade(){
-        when(repo.findAll()).thenReturn(
-                List.of(credentialsModel)
-        );
-
-        List<CredentialsModel> all = service.findAll();
-        assertAll(
-                ()->{
-                    assertNotNull(all);
-                    assertEquals(1, all.size());
-                    verify(repo, times(1)).findAll();
-                }
-        );
-    }
 
 }

--- a/src/test/java/org/devlouco/bacensenderhub/services/CredentialsModelRepositoryServiceTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/CredentialsModelRepositoryServiceTest.java
@@ -75,12 +75,12 @@ class CredentialsModelRepositoryServiceTest {
     }
 
     @Test
-    void Dado_uma_entidade_valida_Quando_feito_o_getCredentialsModel_Entao_deve_retornar_a_entidade(){
+    void Dado_uma_entidade_valida_Quando_feito_o_findByID_Entao_deve_retornar_a_entidade(){
         when(repo.findById(anyLong())).thenReturn(
                 Optional.of(credentialsModel)
         );
 
-        CredentialsModel update = service.findCredentialsById(credentialsModel);
+        CredentialsModel update = service.findById(credentialsModel.getID()).orElse(null);
         assertAll(
                 ()->{
                     assertNotNull(update);
@@ -96,7 +96,7 @@ class CredentialsModelRepositoryServiceTest {
                 List.of(credentialsModel)
         );
 
-        List<CredentialsModel> all = service.findAllCredentials();
+        List<CredentialsModel> all = service.findAll();
         assertAll(
                 ()->{
                     assertNotNull(all);

--- a/src/test/java/org/devlouco/bacensenderhub/services/GenericCrudServiceTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/GenericCrudServiceTest.java
@@ -1,0 +1,113 @@
+package org.devlouco.bacensenderhub.services;
+
+import org.devlouco.bacensenderhub.models.ProtocolModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+abstract class GenericCrudServiceTest<T, ID> {
+
+
+    protected GenericCrudService<T, ID> genericCrudService;
+
+    @Mock
+    protected JpaRepository<T, ID> jpaRepository;
+
+    protected T entity;
+    protected abstract T createEntity();
+
+    protected ID id;
+
+    @BeforeEach
+    void setUp() {
+        entity = createEntity();
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_salvar_Entao_retorna_uma_entidade(){
+        when(jpaRepository.save(any())).thenReturn(
+                entity
+        );
+
+        T save = genericCrudService.save(entity);
+        assertAll(
+                ()->{
+                    assertNotNull(save);
+                    assertEquals(entity,save);
+                    verify(jpaRepository, times(1)).save(any());
+                }
+        );
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_tentar_salvar_nulo_Entao_deve_lancar_exception(){
+        assertThrows(NullPointerException.class, () ->genericCrudService.save(null));
+
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_feito_o_update_Entao_deve_retornar_a_entidade(){
+        when(jpaRepository.save(any())).thenReturn(
+                entity
+        );
+
+        T update = genericCrudService.update(entity);
+        assertAll(
+                ()->{
+                    assertNotNull(update);
+                    assertEquals(entity, update);
+                    verify(jpaRepository,times(1)).save(any());
+                }
+        );
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_feito_o_findById_Entao_deve_retornar_a_entidade(){
+        when(jpaRepository.findById(any())).thenReturn(
+                Optional.of(entity)
+        );
+
+        T update = genericCrudService.findById(id).orElse(null);
+        assertAll(
+                ()->{
+                    assertNotNull(update);
+                    assertEquals(entity, update);
+                    verify(jpaRepository,times(1)).findById(any());
+                }
+        );
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_chamado_findAll_protocolModel_Entao_retorna_uma_lista_de_entidade(){
+        when(jpaRepository.findAll()).thenReturn(
+                List.of(entity)
+        );
+
+        List<T> all = genericCrudService.findAll();
+        assertAll(
+                ()->{
+                    assertNotNull(all);
+                    assertEquals(1, all.size());
+                    verify(jpaRepository, times(1)).findAll();
+                }
+        );
+    }
+
+
+
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/services/ProtocolModelRepositoryServiceTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/ProtocolModelRepositoryServiceTest.java
@@ -1,0 +1,46 @@
+package org.devlouco.bacensenderhub.services;
+
+import org.devlouco.bacensenderhub.models.CompanyModel;
+import org.devlouco.bacensenderhub.models.ProtocolModel;
+import org.devlouco.bacensenderhub.repositories.ProtocolModelRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProtocolModelRepositoryServiceTest {
+
+
+    @Mock
+    private ProtocolModelRepository repo;
+    @InjectMocks
+    private ProtocolModelRepositoryService service;
+
+    private CompanyModel companyModel;
+
+    private ProtocolModel protocolModel;
+
+    @Mock
+    private byte[] fileByte;
+
+    @BeforeEach
+    void setup(){
+        companyModel = new CompanyModel(
+                3027,"90101030201018"
+        );
+
+        protocolModel = new ProtocolModel(
+                1l, LocalDate.now(), "4010","9179ec02b930c1bd44744d784680b21f6ebcb4c1fccbfe1a5bc0f64df7559d58",
+                256,"terste.zip","","544",companyModel,fileByte);
+    }
+
+
+
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/services/ProtocolModelRepositoryServiceTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/ProtocolModelRepositoryServiceTest.java
@@ -87,12 +87,12 @@ class ProtocolModelRepositoryServiceTest {
     }
 
     @Test
-    void Dado_uma_entidade_valida_Quando_feito_o_findProtocolbyId_Entao_deve_retornar_a_entidade(){
+    void Dado_uma_entidade_valida_Quando_feito_o_findById_Entao_deve_retornar_a_entidade(){
         when(repo.findById(anyLong())).thenReturn(
                 Optional.of(protocolModel)
         );
 
-        ProtocolModel update = service.findProtocolbyId(protocolModel);
+        ProtocolModel update = service.findById(protocolModel.getID()).orElse(null);
         assertAll(
                 ()->{
                     assertNotNull(update);
@@ -108,7 +108,7 @@ class ProtocolModelRepositoryServiceTest {
                 List.of(protocolModel)
         );
 
-        List<ProtocolModel> all = service.findAllProtocol();
+        List<ProtocolModel> all = service.findAll();
         assertAll(
                 ()->{
                     assertNotNull(all);

--- a/src/test/java/org/devlouco/bacensenderhub/services/ProtocolModelRepositoryServiceTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/ProtocolModelRepositoryServiceTest.java
@@ -4,6 +4,7 @@ import org.devlouco.bacensenderhub.models.CompanyModel;
 import org.devlouco.bacensenderhub.models.CredentialsModel;
 import org.devlouco.bacensenderhub.models.ProtocolModel;
 import org.devlouco.bacensenderhub.repositories.ProtocolModelRepository;
+import org.devlouco.bacensenderhub.util.TestDataFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,100 +24,28 @@ import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
-class ProtocolModelRepositoryServiceTest {
+class ProtocolModelRepositoryServiceTest extends GenericCrudServiceTest<ProtocolModel, Long>{
 
 
     @Mock
     private ProtocolModelRepository repo;
-    @InjectMocks
-    private ProtocolModelRepositoryService service;
 
-    private CompanyModel companyModel;
 
-    private ProtocolModel protocolModel;
-
-    private byte[] fileByte;
+    @Override
+    protected ProtocolModel createEntity() {
+        return TestDataFactory.createProtocolModel().build();
+    }
 
     @BeforeEach
-    void setup(){
-        companyModel = new CompanyModel(
-                3027,"90101030201018"
-        );
-
-        protocolModel = new ProtocolModel(
-                1l, LocalDate.now(), "4010","9179ec02b930c1bd44744d784680b21f6ebcb4c1fccbfe1a5bc0f64df7559d58",
-                256,"terste.zip","","544",companyModel,fileByte);
-    }
-
-    @Test
-    void Dado_uma_entidade_valida_Quando_salvar_Entao_retorna_uma_entidade(){
-        when(repo.save(any())).thenReturn(
-                protocolModel
-        );
-
-        ProtocolModel save = service.save(protocolModel);
-        assertAll(
-                ()->{
-                    assertNotNull(save);
-                    assertEquals(protocolModel.getHash(),save.getHash());
-                    verify(repo, times(1)).save(any());
-                }
-        );
-    }
-
-    @Test
-    void Dado_uma_entidade_valida_Quando_tentar_salvar_nulo_Entao_deve_lancar_exception(){
-        assertThrows(NullPointerException.class, () ->service.save(null));
+    void setup() {
+        super.setUp();
+        jpaRepository = repo;
+        genericCrudService = new ProtocolModelRepositoryService(repo);
+        id = entity.getID();
 
     }
 
-    @Test
-    void Dado_uma_entidade_valida_Quando_feito_o_update_Entao_deve_retornar_a_entidade(){
-        when(repo.save(any())).thenReturn(
-                protocolModel
-        );
 
-        ProtocolModel update = service.update(protocolModel);
-        assertAll(
-                ()->{
-                    assertNotNull(update);
-                    assertEquals(protocolModel.getHash(), update.getHash());
-                    verify(repo,times(1)).save(any());
-                }
-        );
-    }
-
-    @Test
-    void Dado_uma_entidade_valida_Quando_feito_o_findById_Entao_deve_retornar_a_entidade(){
-        when(repo.findById(anyLong())).thenReturn(
-                Optional.of(protocolModel)
-        );
-
-        ProtocolModel update = service.findById(protocolModel.getID()).orElse(null);
-        assertAll(
-                ()->{
-                    assertNotNull(update);
-                    assertEquals(1l,update.getID());
-                    verify(repo,times(1)).findById(anyLong());
-                }
-        );
-    }
-
-    @Test
-    void Dado_uma_entidade_valida_Quando_chamado_findAll_protocolModel_Entao_retorna_uma_lista_de_entidade(){
-        when(repo.findAll()).thenReturn(
-                List.of(protocolModel)
-        );
-
-        List<ProtocolModel> all = service.findAll();
-        assertAll(
-                ()->{
-                    assertNotNull(all);
-                    assertEquals(1, all.size());
-                    verify(repo, times(1)).findAll();
-                }
-        );
-    }
 
 
 

--- a/src/test/java/org/devlouco/bacensenderhub/services/ProtocolModelRepositoryServiceTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/ProtocolModelRepositoryServiceTest.java
@@ -1,17 +1,26 @@
 package org.devlouco.bacensenderhub.services;
 
 import org.devlouco.bacensenderhub.models.CompanyModel;
+import org.devlouco.bacensenderhub.models.CredentialsModel;
 import org.devlouco.bacensenderhub.models.ProtocolModel;
 import org.devlouco.bacensenderhub.repositories.ProtocolModelRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.parameters.P;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class ProtocolModelRepositoryServiceTest {
@@ -26,7 +35,6 @@ class ProtocolModelRepositoryServiceTest {
 
     private ProtocolModel protocolModel;
 
-    @Mock
     private byte[] fileByte;
 
     @BeforeEach
@@ -38,6 +46,76 @@ class ProtocolModelRepositoryServiceTest {
         protocolModel = new ProtocolModel(
                 1l, LocalDate.now(), "4010","9179ec02b930c1bd44744d784680b21f6ebcb4c1fccbfe1a5bc0f64df7559d58",
                 256,"terste.zip","","544",companyModel,fileByte);
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_salvar_Entao_retorna_uma_entidade(){
+        when(repo.save(any())).thenReturn(
+                protocolModel
+        );
+
+        ProtocolModel save = service.save(protocolModel);
+        assertAll(
+                ()->{
+                    assertNotNull(save);
+                    assertEquals(protocolModel.getHash(),save.getHash());
+                    verify(repo, times(1)).save(any());
+                }
+        );
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_tentar_salvar_nulo_Entao_deve_lancar_exception(){
+        assertThrows(NullPointerException.class, () ->service.save(null));
+
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_feito_o_update_Entao_deve_retornar_a_entidade(){
+        when(repo.save(any())).thenReturn(
+                protocolModel
+        );
+
+        ProtocolModel update = service.update(protocolModel);
+        assertAll(
+                ()->{
+                    assertNotNull(update);
+                    assertEquals(protocolModel.getHash(), update.getHash());
+                    verify(repo,times(1)).save(any());
+                }
+        );
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_feito_o_findProtocolbyId_Entao_deve_retornar_a_entidade(){
+        when(repo.findById(anyLong())).thenReturn(
+                Optional.of(protocolModel)
+        );
+
+        ProtocolModel update = service.findProtocolbyId(protocolModel);
+        assertAll(
+                ()->{
+                    assertNotNull(update);
+                    assertEquals(1l,update.getID());
+                    verify(repo,times(1)).findById(anyLong());
+                }
+        );
+    }
+
+    @Test
+    void Dado_uma_entidade_valida_Quando_chamado_findAll_protocolModel_Entao_retorna_uma_lista_de_entidade(){
+        when(repo.findAll()).thenReturn(
+                List.of(protocolModel)
+        );
+
+        List<ProtocolModel> all = service.findAllProtocol();
+        assertAll(
+                ()->{
+                    assertNotNull(all);
+                    assertEquals(1, all.size());
+                    verify(repo, times(1)).findAll();
+                }
+        );
     }
 
 

--- a/src/test/java/org/devlouco/bacensenderhub/services/ProtocolResponseModelServiceTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/ProtocolResponseModelServiceTest.java
@@ -1,0 +1,44 @@
+package org.devlouco.bacensenderhub.services;
+
+import org.devlouco.bacensenderhub.models.CompanyModel;
+import org.devlouco.bacensenderhub.models.ProtocolModel;
+import org.devlouco.bacensenderhub.models.ProtocolResponseModel;
+import org.devlouco.bacensenderhub.repositories.ProtocolResponseModelRepository;
+import org.devlouco.bacensenderhub.util.TestDataFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProtocolResponseModelServiceTest extends GenericCrudServiceTest<ProtocolResponseModel, Long>{
+
+
+    @Mock
+    private ProtocolResponseModelRepository repository;
+
+
+    @Override
+    protected ProtocolResponseModel createEntity() {
+        return TestDataFactory.createProtocolResponseModel().build();
+    }
+
+
+    @BeforeEach
+    void setup(){
+        super.setUp();
+        jpaRepository = repository;
+        genericCrudService = new ProtocolResponseModelService(repository);
+        id = 1l;
+    }
+
+
+
+
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/services/StaXmlServiceTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/StaXmlServiceTest.java
@@ -1,0 +1,127 @@
+package org.devlouco.bacensenderhub.services;
+
+import org.devlouco.bacensenderhub.models.LinkResponseModel;
+import org.devlouco.bacensenderhub.models.ProtocolModel;
+import org.devlouco.bacensenderhub.models.ProtocolResponseModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StaXmlServiceTest {
+
+
+    @Mock
+    private ProtocolModel protocolModel;
+
+    private StaXmlService staXmlService;
+
+    private String xmlRequest;
+
+    private String xmlResponse;
+
+    @BeforeEach
+    void setUp() {
+        staXmlService = new StaXmlService();
+
+        MockitoAnnotations.openMocks(this);
+
+        xmlRequest = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
+                "<Parametros>\n" +
+                "   <IdentificadorDocumento>4010</IdentificadorDocumento>\n" +
+                "   <Hash>9179ec02b930c1bd44744d784680b21f6ebcb4c1fccbfe1a5bc0f64df7559d58</Hash>\n" +
+                "   <Tamanho>1045</Tamanho>\n" +
+                "   <NomeArquivo>teste.zip</NomeArquivo>\n" +
+                "   <Observacao></Observacao>\n" +
+                "   <Destinatarios></Destinatarios>\n" +
+                "</Parametros>";
+
+        xmlResponse = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
+                "<Resultado xmlns:atom=\"http://www.w3.org/2005/Atom\">\n" +
+                "<Protocolo>90108045</Protocolo>\n" +
+                "<atom:link href=\"https://{host}/staws/arquivos/{protocolo}/conteudo\"\n" +
+                "rel=\"conteudo\" type=\"application/octet-stream\" />\n" +
+                "</Resultado>";
+    }
+
+    @Test
+    void Dado_uma_instancia_do_service_Quando_chamado_o_metodo_marshal_Entao_deve_retornar_um_xml(){
+
+        when(protocolModel.getIdetification()).thenReturn("4010");
+        when(protocolModel.getHash()).thenReturn("9179ec02b930c1bd44744d784680b21f6ebcb4c1fccbfe1a5bc0f64df7559d58");
+        when(protocolModel.getSize()).thenReturn(1045l);
+        when(protocolModel.getDocName()).thenReturn("teste.zip");
+        when(protocolModel.getObservation()).thenReturn("");
+        when(protocolModel.getRecipient()).thenReturn("");
+
+
+        assertEquals(normalizeXml(xmlRequest), normalizeXml(staXmlService.marshalProtocol(protocolModel)));
+
+
+    }
+
+    @Test
+    void Dado_uma_instancia_do_service_Quando_chamado_o_metodo_unMarshalProtocol_Entao_deve_retornar_um_objeto_ProtocolModel(){
+        when(protocolModel.getHash()).thenReturn("9179ec02b930c1bd44744d784680b21f6ebcb4c1fccbfe1a5bc0f64df7559d58");
+        ProtocolModel unmarshalProtocol = staXmlService.unmarshalProtocol(xmlRequest);
+        assertEquals(protocolModel.getHash(), unmarshalProtocol.getHash());
+    }
+
+    @Test
+    void Dado_uma_instancia_do_service_Quando_chamado_os_metodos_com_valores_null_Entao_deve_lancar_exception(){
+        assertAll(
+                () ->{
+                    assertThrows(IllegalArgumentException.class, () -> staXmlService.marshalProtocol(null));
+                    assertThrows(IllegalArgumentException.class, () -> staXmlService.unmarshalProtocol(null));
+                    assertThrows(IllegalArgumentException.class, () -> staXmlService.unmarshalProtocolResponse(null));
+                }
+        );
+
+    }
+
+    @Test
+    void Dado_uma_instancia_do_service_Quando_chamado_o_unMarshal_com_string_sem_serializacao_xml_Entao_deve_lancar_exception(){
+        assertAll(
+                () ->{
+                    assertThrows(RuntimeException.class, () -> staXmlService.unmarshalProtocol("oaisdio"));
+                    assertThrows(RuntimeException.class, () -> staXmlService.unmarshalProtocolResponse("asopdiopas"));
+                }
+        );
+
+    }
+
+    @Test
+    void Dado_uma_instancia_do_service_Quando_chamado_o_unmarshalProtocolResponse_Entao_deve_retornar_um_objeto_ProtocolResponseModel(){
+        LinkResponseModel linkTest= new LinkResponseModel(
+                "https://{host}/staws/arquivos/{protocolo}/conteudo","conteudo","application/octet-stream"
+        );
+
+        ProtocolResponseModel protocolResponseModel = staXmlService.unmarshalProtocolResponse(xmlResponse);
+
+        assertAll(()->{
+            assertEquals("90108045",protocolResponseModel.getProtocol());
+            assertEquals(linkTest, protocolResponseModel.getLinkContent());
+        });
+
+
+
+    }
+
+
+
+    private String normalizeXml(String xml) {
+        return xml.trim()
+                // Remove espaços excessivos entre tags
+                .replaceAll(">\\s+<", "><")
+                // Padroniza as quebras de linha para um formato único
+                .replaceAll("\\r?\\n", "\n")
+                // Remove espaços no início e no fim de cada linha
+                .replaceAll("\\s*\n\\s*", "\n");
+    }
+
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/services/WebServiceSenderClientTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/services/WebServiceSenderClientTest.java
@@ -1,0 +1,123 @@
+package org.devlouco.bacensenderhub.services;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.devlouco.bacensenderhub.models.CompanyModel;
+import org.devlouco.bacensenderhub.models.CredentialsModel;
+import org.devlouco.bacensenderhub.models.ProtocolModel;
+import org.devlouco.bacensenderhub.models.ProtocolResponseModel;
+import org.devlouco.bacensenderhub.repositories.CredentialsModelRepository;
+import org.devlouco.bacensenderhub.util.TestDataFactory;
+import org.devlouco.bacensenderhub.util.headerStrategy.HeaderProtocol;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.webservices.client.AutoConfigureWebServiceClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.w3c.dom.stylesheets.LinkStyle;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebServiceClient
+@ExtendWith({WireMockExtension.class, SpringExtension.class})
+class WebServiceSenderClientTest {
+
+    private HeaderProtocol headerProtocol;
+
+
+    private ProtocolModel protocolModel;
+    private List<ProtocolModel> protocolModels;
+    private CredentialsModel credentialsModel;
+    private WireMockServer wireMockServer;
+    @Autowired
+    private StaXmlService staXmlService;
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @MockBean
+    private CredentialsModelRepository credentialsModelRepository;
+
+    @MockBean
+    private CredentialsModelRepositoryService credentialsModelRepositoryService;
+
+    @InjectMocks
+    private ProtocolFactoryService protocolFactoryService;
+
+    @InjectMocks
+    @Autowired
+    private WebServiceSenderClient webServiceSenderClient;
+
+    @BeforeEach
+    void setUp() throws IOException {
+
+        protocolModel = TestDataFactory.createProtocolModel().build();
+        protocolModels = TestDataFactory.createProtocolResponseModelList();
+        credentialsModel = TestDataFactory.createCredentialsModel().build();
+
+    }
+
+    @Test
+    void Dado_um_webServiceClient_valido_Quando_chamar_createProtocol_Entao_deve_retornar_um_xml_valido() throws ExecutionException, InterruptedException {
+
+        String xml = staXmlService.marshalProtocol(protocolModel);
+
+        when(credentialsModelRepositoryService.getCredentialsModelByCoop(anyInt()))
+                .thenReturn(credentialsModel);
+
+        when(credentialsModelRepository.findByCoop(anyInt())).thenReturn(
+                Optional.of(credentialsModel)
+        );
+
+
+        webServiceSenderClient.setURI("http://localhost:8181/staws/arquivos/");
+        //nesse metodo e usa o block para fazer as asserções das resposta do stub
+        List<ProtocolResponseModel> protocols = webServiceSenderClient.createProtocols(protocolModels).collectList().block();
+
+        assertEquals(1000, protocols.size());
+        // Verifica se a requisição POST foi feita conforme esperado
+
+
+
+    }
+
+    private String normalizeXml(String xml) {
+        return xml.trim()
+                // Remove espaços excessivos entre tags
+                .replaceAll(">\\s+<", "><")
+                // Padroniza as quebras de linha para um formato único
+                .replaceAll("\\r?\\n", "\n")
+                // Remove espaços no início e no fim de cada linha
+                .replaceAll("\\s*\n\\s*", "\n");
+    }
+
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/util/BasicAuthTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/util/BasicAuthTest.java
@@ -1,0 +1,45 @@
+package org.devlouco.bacensenderhub.util;
+
+import org.devlouco.bacensenderhub.models.CompanyModel;
+import org.devlouco.bacensenderhub.models.CredentialsModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BasicAuthTest {
+
+    private BasicAuth basicAuth;
+
+    private CompanyModel companyModel;
+    private CredentialsModel credentialsModel;
+
+    @BeforeEach
+    void setUp() {
+
+        basicAuth = new BasicAuth();
+
+        companyModel = new CompanyModel(
+                3027, "90380840189890"
+        );
+
+        credentialsModel = new CredentialsModel(
+                1l,"teste2","teste2",companyModel
+        );
+
+
+    }
+
+    @Test
+    void testBasicAuth() {
+
+        String basicAuthLocal = "Basic dGVzdGUyOnRlc3RlMg==";
+
+        assertEquals(basicAuthLocal, basicAuth.createBasicAuthHeader(credentialsModel));
+
+
+    }
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/util/TestDataFactory.java
+++ b/src/test/java/org/devlouco/bacensenderhub/util/TestDataFactory.java
@@ -1,0 +1,96 @@
+package org.devlouco.bacensenderhub.util;
+
+import org.devlouco.bacensenderhub.models.*;
+import org.devlouco.bacensenderhub.services.ProtocolFactoryService;
+import wiremock.org.eclipse.jetty.util.security.Credential;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestDataFactory {
+
+    private static ProtocolFactoryService protocolFactoryService;
+
+    public TestDataFactory(ProtocolFactoryService protocolFactoryService) {
+        this.protocolFactoryService = protocolFactoryService;
+    }
+
+    public static CompanyModel.Builder createCompanyModel() {
+        return CompanyModel.builder()
+                .withID(1l)
+                .withCoop(3027)
+                .withCnpj("09897648571235");
+    }
+    public static CompanyModel.Builder createCompanyModelNull() {
+        return CompanyModel.builder();
+    }
+
+    public static CompanyModel.Builder createCompanyModeWithCredentials() {
+        return createCompanyModel()
+                .withCredentials(createCredentialsModel().build());
+
+    }
+
+
+    public static CredentialsModel.Builder createCredentialsModel() {
+        return CredentialsModel.builder()
+                .withLogin("teste")
+                .withPassword("teste");
+    }
+
+    public static CredentialsModel.Builder createCredentialsModelNull() {
+        return CredentialsModel.builder();
+    }
+
+    public static ProtocolModel.Builder createProtocolModel() {
+        return ProtocolModel.builder()
+                .withID(1l)
+                .withDate(LocalDate.now())
+                .withIdetification("4010")
+                .withHash("9179ec02b930c1bd44744d784680b21f6ebcb4c1fccbfe1a5bc0f64df7559d58")
+                .withSize(256)
+                .withDocName("teste.zip")
+                .withObservation("")
+                .withRecipient("")
+                .withFilesBytes("Conteúdo binário simulado".getBytes(StandardCharsets.UTF_8))
+                .withCompany(createCompanyModel().build()
+                );
+
+    }
+
+    public static ProtocolModel.Builder createProtocolModelNull() {
+        return ProtocolModel.builder();
+    }
+
+    public static ProtocolResponseModel.Builder createProtocolResponseModel() {
+        return ProtocolResponseModel.builder()
+                .withID(1l)
+                .withProtocol("90108045")
+                .withLinkContent(
+                        new LinkResponseModel(
+                              "https://{host}/staws/arquivos/{protocolo}/conteudo","conteudo","application/octet-stream"
+                        )
+                )
+                .withCompanyModel(createCompanyModel().build());
+    }
+
+    public static ProtocolResponseModel.Builder createProtocolResponseModelNull() {
+        return ProtocolResponseModel.builder();
+    }
+
+    public static List<ProtocolModel> createProtocolResponseModelList() {
+        List<ProtocolModel> protocolModelList = new ArrayList<>();
+        for(int i=0;i < 1000;i++){
+            ProtocolModel prot = createProtocolModel().build();
+            protocolModelList.add(prot);
+        }
+
+        return protocolModelList;
+    }
+
+
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/util/headerStrategy/BacenHeaderTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/util/headerStrategy/BacenHeaderTest.java
@@ -1,0 +1,63 @@
+package org.devlouco.bacensenderhub.util.headerStrategy;
+
+import org.devlouco.bacensenderhub.models.CompanyModel;
+import org.devlouco.bacensenderhub.models.CredentialsModel;
+import org.devlouco.bacensenderhub.util.BasicAuth;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.*;
+
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+
+import static org.junit.jupiter.api.Assertions.*;
+@ExtendWith(MockitoExtension.class)
+abstract class BacenHeaderTest<T> {
+
+@Mock
+private BasicAuth basicAuth;
+
+
+    protected BacenHeader bacenHeader;
+
+    protected T entity;
+    protected T basicAuthHeader;
+
+    protected abstract T createEntity();
+
+
+
+
+    @BeforeEach
+    void setUp() {
+        entity = createEntity();
+    }
+
+    @Test
+    void Dado_a_implementaçao_protocol_Quando_chamado_getHeader_Entao_nao_deve_retornar_null(){
+
+
+        when(basicAuth.createBasicAuthHeader(any())).thenReturn(
+                basicAuthHeader.toString()
+        );
+
+
+        HttpHeaders header = bacenHeader.getHeader((CredentialsModel) entity);
+
+        assertAll(
+                ()->{
+                    assertNotNull(header);
+                    assertEquals(basicAuthHeader, header.getFirst("Authorization"));
+                    verify(basicAuth, times(1)).createBasicAuthHeader((CredentialsModel) entity);
+                    verify(bacenHeader, times(1)).getHeader((CredentialsModel) entity);
+                }
+        );
+
+    }
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/util/headerStrategy/HeaderFileUploadTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/util/headerStrategy/HeaderFileUploadTest.java
@@ -1,0 +1,48 @@
+package org.devlouco.bacensenderhub.util.headerStrategy;
+
+import org.devlouco.bacensenderhub.models.CompanyModel;
+import org.devlouco.bacensenderhub.models.CredentialsModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.springframework.http.HttpHeaders;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HeaderFileUploadTest extends BacenHeaderTest{
+
+    @Spy
+    @InjectMocks
+    private HeaderFileUpload headerFileUpload;
+
+    private CredentialsModel credentialsModel;
+    private CompanyModel companyModel;
+    private HttpHeaders headers;
+
+    @Override
+    protected CredentialsModel createEntity() {
+        companyModel = new CompanyModel(
+                3027,"90380840189890"
+        );
+
+        credentialsModel = new CredentialsModel(
+                1l,"teste","teste",companyModel
+        );
+
+        return credentialsModel;
+    }
+
+    @BeforeEach
+    void setUp() {
+
+        basicAuthHeader = "Basic dGVzdGU6dGVzdGU=";
+        super.setUp();
+        bacenHeader = headerFileUpload;
+
+    }
+
+
+
+
+
+}

--- a/src/test/java/org/devlouco/bacensenderhub/util/headerStrategy/HeaderProtocolTest.java
+++ b/src/test/java/org/devlouco/bacensenderhub/util/headerStrategy/HeaderProtocolTest.java
@@ -1,0 +1,44 @@
+package org.devlouco.bacensenderhub.util.headerStrategy;
+
+import org.devlouco.bacensenderhub.models.CompanyModel;
+import org.devlouco.bacensenderhub.models.CredentialsModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.springframework.http.HttpHeaders;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HeaderProtocolTest extends BacenHeaderTest{
+
+    private CompanyModel companyModel;
+    private CredentialsModel credentialsModel;
+
+    @InjectMocks
+    @Spy
+    private HeaderProtocol headerProtocol;
+
+    @Override
+    protected CredentialsModel createEntity() {
+        companyModel = new CompanyModel(
+                3027,"45986258491235"
+        );
+
+        credentialsModel = new CredentialsModel(
+                1l,"teste2","teste2",companyModel
+        );
+
+        return credentialsModel;
+    }
+
+
+    @BeforeEach
+    void setUp() {
+        super.setUp();
+        super.setUp();
+        bacenHeader = headerProtocol;
+        basicAuthHeader = "Basic dGVzdGUyOnRlc3RlMg==";
+
+
+    }
+}

--- a/src/test/mappings/bacen-webservice-stubs.json
+++ b/src/test/mappings/bacen-webservice-stubs.json
@@ -1,0 +1,30 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "POST",
+        "urlPathPattern": "/staws/arquivos/",
+        "headers": {
+          "Content-Type": {
+            "equalTo": "application/xml"
+          },
+          "Authorization": {
+            "equalTo": "Basic dGVzdGU6dGVzdGU="
+          }
+        },
+        "bodyPatterns": [
+          {
+            "equalToXml": "<Parametros>\n<IdentificadorDocumento>4010</IdentificadorDocumento>\n<Hash>9179ec02b930c1bd44744d784680b21f6ebcb4c1fccbfe1a5bc0f64df7559d58</Hash>\n<Tamanho>256</Tamanho>\n<NomeArquivo>teste.zip</NomeArquivo>\n<Observacao></Observacao>\n<Destinatarios></Destinatarios>\n</Parametros>"
+          }
+        ]
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/xml"
+        },
+        "body": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<Resultado xmlns:atom=\"http://www.w3.org/2005/Atom\">\n<Protocolo>90108045</Protocolo>\n<atom:link href=\"https://{host}/staws/arquivos/{protocolo}/conteudo\"\nrel=\"conteudo\" type=\"application/octet-stream\" />\n</Resultado>"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Motivação
Implementar os models de dados necessários para representar as entidades, compania, crendenciais, protocol, reposta do protocolo.

### O que foi feito
- Adicionado classes models para representar as entidades, compania, crendenciais, protocol, reposta do protocolo.
- As classes de teste verificam regras de negócios como validação de campos obrigatórios, formato de dados, e relacionamentos entre entidades.

### Como testar
1. Executar as classes no pacote test/java/org/devlouco/bacensenderhub/models e verificar se todos os testes de validação de regras de negócios, como validação de campos obrigatórios e formatos de dados, estão sendo aprovados.

### Tarefas pendentes
- [ ] Atualizar a documentação da API para incluir a descrição dos novos models (CompanyModel, CredentialsModel, ProtocolModel, ProtocolResponseModel), além de exemplos de requisições que utilizam esses modelos.
- [ ] Criar testes de integração para cobrir cenários com models

### Referências
- Issue #1: Adicionar modelos de dados a API.